### PR TITLE
fix: sound timer stuck at 1 due to -= instead of = in decrement logic

### DIFF
--- a/src/registers.rs
+++ b/src/registers.rs
@@ -34,7 +34,7 @@ impl Registers {
                     let val = (difference.as_millis() / 16) as u8;
                     let s = *sound;
                     if s != 0 {
-                        *sound -= s.checked_sub(val).unwrap_or(0);
+                        *sound = s.checked_sub(val).unwrap_or(0);
                     }
                     let d = *delay;
                     if d != 0 {


### PR DESCRIPTION
Sound timer used `*sound -=` which kept value at 1 when it should reach 0. Delay timer on next line used correct `*delay =` pattern.